### PR TITLE
ReStock Whitelist

### DIFF
--- a/GameData/LTech/Patches/LTech.restockwhitelist
+++ b/GameData/LTech/Patches/LTech.restockwhitelist
@@ -1,0 +1,4 @@
+// Whitelist to enable some LTech part textures to work correctly when ReStock is installed.
+// See: https://github.com/PorktoberRevolution/ReStocked/wiki/Asset-Blacklist-and-Whitelist
+
+Squad/Parts/Science/ScienceBox/Container


### PR DESCRIPTION
Adds Sciencebox container texture to a ReStock whitelist so container parts in LTech are display the correct texture rather than as pure white.